### PR TITLE
Fix pauseontouch

### DIFF
--- a/source/jquery.slides.coffee
+++ b/source/jquery.slides.coffee
@@ -516,7 +516,7 @@
         # Stop/pause slideshow on mouse enter
         slidesContainer.bind "mouseenter", =>
           clearTimeout @data.restartDelay
-					$.data this, "restartDelay", null
+          $.data this, "restartDelay", null
           @stop()
 
         # Play slideshow on mouse leave

--- a/source/jquery.slides.coffee
+++ b/source/jquery.slides.coffee
@@ -393,6 +393,12 @@
     @data = $.data this
     touches = e.originalEvent.touches[0]
 
+    # Define slides container
+    slidesContainer = $(".slidesjs-container", $element)
+
+    # Trigger mouseenter (pauses if pauseOnHover is set)
+    slidesContainer.trigger "mouseenter"
+
     # Setup the next and previous slides for swiping
     @_setuptouch()
 
@@ -412,6 +418,12 @@
     $element = $(@element)
     @data = $.data this
     touches = e.originalEvent.touches[0]
+
+    # Define slides container
+    slidesContainer = $(".slidesjs-container", $element)
+
+    # Trigger mouseleave (unpauses if pauseOnHover is set)
+    slidesContainer.trigger "mouseleave"
 
     # Define slides control
     slidesControl = $(".slidesjs-control", $element)


### PR DESCRIPTION
When config options pauseOnTouch and auto are set to true, slide transitions stop when the mouse is over the slides container (this is done via mouseenter and mouseleave events).

However, transitions are not paused on a mobile device when the slides are being dragged via touch.

This patch pauses transitions by triggering mouseenter and mouseleave in the touchstart and touchend events, respectively.

Note that I did not compile the coffeescript nor generate a minified version in this pull request.

Thanks for your awesome slider!