### PR TITLE
fix conflict while update and animate at the same time

### DIFF
--- a/source/jquery.slides.coffee
+++ b/source/jquery.slides.coffee
@@ -293,10 +293,11 @@
     @data = $.data this
 
     # Hide all slides expect current
-    $(".slidesjs-control", $element).children(":not(:eq(" + @data.current + "))").css
-      display: "none"
-      left: 0
-      zIndex: 0
+    if !@data.animating
+      $(".slidesjs-control", $element).children(":not(:eq(" + @data.current + "))").css
+        display: "none"
+        left: 0
+        zIndex: 0
 
     # Get the new width and height
     width = $element.width()

--- a/source/jquery.slides.js
+++ b/source/jquery.slides.js
@@ -206,11 +206,13 @@
       var $element, height, width;
       $element = $(this.element);
       this.data = $.data(this);
-      $(".slidesjs-control", $element).children(":not(:eq(" + this.data.current + "))").css({
-        display: "none",
-        left: 0,
-        zIndex: 0
-      });
+      if (!this.data.animating) {
+        $(".slidesjs-control", $element).children(":not(:eq(" + this.data.current + "))").css({
+          display: "none",
+          left: 0,
+          zIndex: 0
+        });
+      }
       width = $element.width();
       height = (this.options.height / this.options.width) * width;
       this.options.width = width;


### PR DESCRIPTION
Bug: When resize browser's window while Slides switch it's item, The erea of slides will be all blank, all is white.