### PR TITLE
Return the slider controller

### DIFF
--- a/source/jquery.slides.js
+++ b/source/jquery.slides.js
@@ -192,7 +192,7 @@
       if (this.options.play.auto) {
         this.play();
       }
-      return this.options.callback.loaded(this.options.start);
+      return this.options.callback.loaded(this.options.start, a);
     };
     Plugin.prototype._setActive = function(number) {
       var $element, current;


### PR DESCRIPTION
Return the slider controller to allow developers to control the slider from outside, and allow them to create custom paginations